### PR TITLE
Release jest-joi 1.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-joi",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-joi",
-      "version": "1.1.17",
+      "version": "1.1.18",
       "license": "MIT",
       "dependencies": {
         "@aitodotai/json-stringify-pretty-compact": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-joi",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Jest matcher for Joi schemas",
   "homepage": "https://github.com/agorischek/jest-joi",
   "repository": "https://github.com/agorischek/jest-joi.git",


### PR DESCRIPTION
## What changed

- bump `jest-joi` from 1.1.17 to 1.1.18

## Why

This patch release ships the dependency-security and release-pipeline modernization from #28 and proves the new npm OIDC trusted-publishing path before Garden release automation is enabled.

## Impact

The public matcher API is unchanged. The release contains the remediated dependency graph, modernized package contents, and current runtime tooling already validated on `main`.

## Validation

- `npx --yes npm@11.18.0 ci`
- `npm run validate` (82 tests, 100% coverage, zero audit findings)
- package smoke test and `npm pack --dry-run` for `jest-joi@1.1.18`
- `git diff --check`
