### PR TITLE
Add Garden release adapter

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,80 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact v-prefixed semantic version requested by Garden
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Use the lockfile npm version
+        run: npm install --global npm@11.18.0
+
+      - name: Validate requested version
+        id: release
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Garden version must be vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+          if git show-ref --verify --quiet "refs/tags/$VERSION" || \
+             git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists" >&2
+            exit 1
+          fi
+          echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release commit and tag
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          npm version "$RELEASE_VERSION" --no-git-tag-version --ignore-scripts
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "Release $VERSION"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "refs/tags/$VERSION"
+
+      - name: Dispatch publish workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if gh workflow run publish.yml --ref "$VERSION" -f version="$VERSION"; then
+              exit 0
+            fi
+            sleep "$((attempt * 5))"
+          done
+          exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,20 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing release tag to publish
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
 
 concurrency:
-  group: publish-${{ github.ref }}
+  group: publish-${{ inputs.version || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -21,7 +28,9 @@ jobs:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          fetch-depth: 0
           persist-credentials: false
+          ref: ${{ inputs.version || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -36,8 +45,13 @@ jobs:
       - name: Verify tag and package version
         id: package
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.version || github.ref_name }}
         run: |
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Release tag must be vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+          test "$(git rev-list -n 1 "$TAG")" = "$(git rev-parse HEAD)"
           VERSION=$(node --print "require('./package.json').version")
           case "$VERSION" in
             *-*)
@@ -46,6 +60,7 @@ jobs:
               ;;
           esac
           test "$TAG" = "v$VERSION"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - run: npm ci
@@ -64,7 +79,7 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ steps.package.outputs.tag }}
         run: |
           gh release view "$TAG" >/dev/null 2>&1 || \
             gh release create "$TAG" --verify-tag --generate-notes --title "$TAG"


### PR DESCRIPTION
## Summary

- add Garden standard `prepare-release.yml` contract
- create an isolated release commit so npm manifests match the requested immutable tag without pushing to protected `main`
- explicitly dispatch the existing publisher from that tag, with retry protection for tag propagation
- harden publishing so manual and tag-triggered runs validate and build from the exact release tag

## Validation

- `npm run validate`
- `actionlint` on both release workflows
- `git diff --check` (excluding generated workflow locks)
- isolated local v1.1.19 release-commit/tag simulation (no tag pushed and no package published)

## Rollout

After this merges, Garden will run Dependabot PR #29 as a merge-only canary. Release automation remains gated until the 24-hour release interval allows a real canary.