### PR TITLE
Require exact semantic release tags

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          if ! printf '%s' "$VERSION" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
             echo "Garden version must be vMAJOR.MINOR.PATCH" >&2
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ inputs.version || github.ref }}
+          ref: refs/tags/${{ inputs.version || github.ref_name }}
 
       - name: Set up Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -47,11 +47,13 @@ jobs:
         env:
           TAG: ${{ inputs.version || github.ref_name }}
         run: |
-          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          if ! printf '%s' "$TAG" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
             echo "Release tag must be vMAJOR.MINOR.PATCH" >&2
             exit 1
           fi
-          test "$(git rev-list -n 1 "$TAG")" = "$(git rev-parse HEAD)"
+          TAG_REF="refs/tags/$TAG"
+          git show-ref --verify --quiet "$TAG_REF"
+          test "$(git rev-parse "$TAG_REF^{commit}")" = "$(git rev-parse HEAD)"
           VERSION=$(node --print "require('./package.json').version")
           case "$VERSION" in
             *-*)


### PR DESCRIPTION
## Summary

- reject semantic versions with leading-zero components
- check out the fully qualified `refs/tags/...` ref in the publisher
- verify the peeled tag commit exactly matches the checked-out commit
- prevent a version-shaped branch from being mistaken for a release tag

## Validation

- `npm run validate`
- `actionlint` on both release workflows
- exact-tag ambiguity simulation with same-named branch and annotated tag
- semantic-version acceptance/rejection cases
- CodeRabbit Pro follow-up review: zero findings